### PR TITLE
Logger `Format` as `untagged` in JSON

### DIFF
--- a/trace4rs-config/src/config.rs
+++ b/trace4rs-config/src/config.rs
@@ -158,7 +158,7 @@ pub struct Logger {
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
-    serde(rename_all = "lowercase")
+    serde(untagged, rename_all = "lowercase")
 )]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub enum Format {


### PR DESCRIPTION
Currently `Format` is tagged, so `Format::Cusom("My Format: {t}: {m}{n}".into())` is serialized as:
```
"format": {
    "custom": "My Format: {t}: {m}{n}"
},
```

This PR makes `Format` untagged, so it serializes as:
```
"format": "My Format: {t}: {m}{n}",
```