### PR TITLE
Add a custom serializer for untagged enum unit variants

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
-        "fmtorp"
+        "fmtorp",
+        "messageonly"
     ]
 }


### PR DESCRIPTION
Untagged enum unit variants always serialize as `null`: https://github.com/serde-rs/serde/issues/1560

Therefore, a custom serializer must be implemented in order to create the desired behavior, which is to output the actual unit variant values/names.

An additional PR has been opened to mention this in the `serde` documentation: https://github.com/serde-rs/serde-rs.github.io/pull/142