### PR TITLE
Fix Schemars `with` for a module

### DIFF
--- a/trace4rs-config/src/config.rs
+++ b/trace4rs-config/src/config.rs
@@ -207,8 +207,10 @@ mod format {
 pub enum Format {
     #[default]
     #[cfg_attr(feature = "serde", serde(with = "format::normal"))]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     Normal,
     #[cfg_attr(feature = "serde", serde(with = "format::messageonly"))]
+    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     MessageOnly,
     Custom(String),
 }


### PR DESCRIPTION
Our use of the `with` field for `serde` breaks `schemars` as `schemars` can only handle a type and not a module. So instead of the custom modules simply use `String` as the type.

See:
- https://github.com/GREsau/schemars/issues/89
- https://github.com/GREsau/schemars/issues/114
- https://graham.cool/schemars/deriving/attributes/#with
