### PR TITLE
Use GitHub variables instead of event object

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Benchmark trace4rs PR with Bencher
         run: |
           bencher run \
-          --if-branch '${{ github.event.pull_request.head.ref }}' \
-          --else-if-branch '${{ github.event.pull_request.base.ref }}' \
+          --if-branch "$GITHUB_REF_NAME" \
+          --else-if-branch "$GITHUB_BASE_REF" \
           --else-if-branch main \
+          --github-actions "${{ secrets.GITHUB_TOKEN }}" \
+          --token "${{ secrets.BENCHER_API_TOKEN }}" \
           --err \
-          --github-actions '${{ secrets.GITHUB_TOKEN }}' \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
           "cargo bench"


### PR DESCRIPTION
Even though the single quotes were enough to fix the pwn request issue with `${{ github.event.pull_request.head.ref }}`, I think it would be safer going forward to just use the already sanitized GitHub variables: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables